### PR TITLE
update to target_link_libraries target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,4 @@ find_package(cpr CONFIG REQUIRED)
 # adding all files
 add_executable(main main.cpp wikiscraper.cpp error.cpp)
 
-target_link_libraries(main PRIVATE cpr)
+target_link_libraries(main PRIVATE cpr::cpr)


### PR DESCRIPTION
# Overview
Accommodate for new version of vcpkg/cpr, as per @yihengwuKP's suggestion here: https://github.com/snme/cs106L-assignment1/issues/1. 

## Description of Issue/Feature
We use a C++ internet library called [CPR](https://docs.libcpr.org) to make HTTP GET requests. For the past few months, we've been using VCPKG to handle installation of cmake, CPR, and dependencies in students' personal AFS directory spaces. In the CMakeLists.txt file for building this project, in order to include the CPR library, we've used the following line: `target_link_libraries(main PRIVATE cpr)`. However, in a recent change, this has been deprecated. As a result, new installations of CPR can no longer be included in the project like this.

## Description of Changes
Instead, a great suggestion from [https://github.com/snme/cs106L-assignment1/issues/1](https://github.com/snme/cs106L-assignment1/issues/1) was to change `target_link_libraries(main PRIVATE cpr)` in the cmakelists file to `target_link_libraries(main PRIVATE cpr::cpr)`. As a result, this PR resolves #1 fully.

## Screenshots
Here are the effects of installing the repo as instructed without this change.
<img width="826" alt="image" src="https://user-images.githubusercontent.com/22281891/147511003-c8aec199-2d3f-455b-a7a7-4b70cbcd3fa4.png">

Now, with this change, here is a screenshot of the installation (`./setup.sh`) running smoothly:
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/22281891/147511061-e8693756-ee46-4e39-8f89-a974379a7192.png">